### PR TITLE
Add Variable definitions using the 'define' func

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,6 @@
 TODO
 ====
+- [x] Add variables
 - [ ] Convert operations into Environment and convert them into
   pre-defined functions
 - [ ] Provide flags to switch between repl, compiler, and outputs

--- a/lexer.go
+++ b/lexer.go
@@ -26,7 +26,7 @@ const (
 	NUM = iota
 	OP
 	SYM
-	DEFINE
+	DEF
 	LPEREN
 	RPEREN
 	EOF
@@ -41,7 +41,7 @@ var TokenId = map[byte]string{
 	LPEREN: "(",
 	RPEREN: ")",
 	SYM:    "SYM",
-	DEFINE: "DEF",
+	DEF:    "DEF",
 	EOF:    "EOF",
 	ILLEG:  "ILLEG",
 }
@@ -139,7 +139,7 @@ func GetToken(b byte, reader *bufio.Reader) *Token {
 		b := getWord(b, reader)
 		switch b {
 		case "define":
-			return &Token{DEFINE, 0, b}
+			return &Token{DEF, 0, b}
 		}
 		return &Token{SYM, 0, b}
 	}

--- a/parser.go
+++ b/parser.go
@@ -9,37 +9,55 @@ type ParseTree struct {
 	left, right *ParseTree
 }
 
+type Env struct {
+	symbols map[string]int
+}
+
 // Given a list of tokens return an AST
-func Expression(tz *Tokenizer) *ParseTree {
+func Expression(env *Env, tz *Tokenizer) *ParseTree {
 	t := tz.Peek()
-	if tz.Match(NUM) {
+	if tz.Match(NUM) || tz.Match(SYM) {
 		return &ParseTree{token: t, left: nil, right: nil}
 	} else if tz.Match(LPEREN) {
-		t = tz.Peek()
-		if tz.Match(OP) {
-			left := Expression(tz)
-			right := Expression(tz)
+		if t = tz.Peek(); tz.Match(OP) {
+			left := Expression(env, tz)
+			right := Expression(env, tz)
 			tz.Match(RPEREN)
 			return &ParseTree{token: t, left: left, right: right}
+		} else if tz.Match(DEF) {
+			if sym := tz.Peek(); tz.Match(SYM) {
+				if num := tz.Peek(); tz.Match(NUM) {
+					env.symbols[sym.Word] = num.Val
+					return &ParseTree{token: sym, left: nil, right: nil}
+				}
+			}
 		}
 	}
 	return nil
 }
 
 // Parser needs to construct the grammar it expects
-func Parse(tz *Tokenizer) int {
-	pt := Expression(tz)
-	return value(pt)
+func Parse(env *Env, tz *Tokenizer) int {
+	pt := Expression(env, tz)
+	/*
+		// Debug environment
+		for k, v := range env.symbols {
+			fmt.Printf("%s: %d\n", k, v)
+		}
+	*/
+	return value(env, pt)
 }
 
 // Walk the tree to determine the value
-func value(pt *ParseTree) int {
+func value(env *Env, pt *ParseTree) int {
 	if pt != nil {
 		t := pt.token
 		if t.Id == OP {
-			x := value(pt.left)
-			y := value(pt.right)
+			x := value(env, pt.left)
+			y := value(env, pt.right)
 			return result(t.Word, x, y)
+		} else if t.Id == SYM {
+			return env.symbols[t.Word]
 		} else if t.Id == NUM {
 			return t.Val
 		}

--- a/repl.go
+++ b/repl.go
@@ -19,11 +19,14 @@ const PS1 = "> "
 // 'Read, Evaluate, Print, Loop'
 func Repl() {
 	reader := bufio.NewReader(os.Stdin)
+	var env = &Env{
+		symbols: make(map[string]int),
+	}
 	for {
 		fmt.Print(PS1)
 		text := Read(reader)
 		lineReader := bufio.NewReader(strings.NewReader(text))
-		output := Eval(lineReader)
+		output := Eval(env, lineReader)
 		Print(output)
 	}
 }
@@ -46,8 +49,8 @@ func Print(text string) {
 }
 
 // Evaluate: Tokenize the stream (AST), parse, and return the result
-func Eval(r *bufio.Reader) string {
+func Eval(env *Env, r *bufio.Reader) string {
 	tokenizer := Tokenize(r)
-	result := Parse(tokenizer)
+	result := Parse(env, tokenizer)
 	return strconv.Itoa(result)
 }


### PR DESCRIPTION
Allows defining variables using the '(define a <num>)' syntax that can
be used in later calls.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>